### PR TITLE
Introduced the libraryPath setting and updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+gulpfile.js
+tests
+.vscode

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ module.exports = function(args){
 		watch: false,
 		update_metadata: false,
 		files_metadata: [],
-		publish: false
+		publish: false,
+		libraryPath: ""
 	}
 	
 	if(!args){
@@ -51,6 +52,7 @@ module.exports = function(args){
 		options.files_metadata = args.files_metadata || options.files_metadata;
 		options.publish = args.publish || options.publish;
 		options.startFolder = args.startFolder || "";
+		options.libraryPath = args.libraryPath || "";
 	}
 	
 	var getFormattedPrincipal = function (principalName, hostName, realm){
@@ -256,7 +258,7 @@ module.exports = function(args){
         }
 		var filename = file.relative.substring(ix+1)
 		return {
-			library: library,
+			library: options.libraryPath !== "" ? options.libraryPath + path.sep + library : library,
 			filename: filename
 		};
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-spsync",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Gulp plugin that syncs with a library in SharePoint Online",
   "main": "index.js",
   "scripts": {
@@ -19,11 +19,12 @@
     "office365"
   ],
   "dependencies": {
-    "through2": "^2.0.1",
-    "request-promise": "^4.1.1",
-    "url": "^0.11.0",
-    "gulp-util": "^3.0.7",
-    "util": "^0.10.3"
+    "gulp-util": "3.0.8",
+    "request": "2.79.0",
+    "request-promise": "4.1.1",
+    "through2": "2.0.3",
+    "url": "0.11.0",
+    "util": "0.10.3"
   },
   "author": "Wictor Wilén",
   "license": "MIT",
@@ -37,6 +38,5 @@
       "email": "wictor@wictorwilen.se"
     }
   ],
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
Hi @wictorwilen,

First of all, I updated the dependencies. This was needed because `request-promise` now also requires for you to install the `request` library.

Second, I introduced a new setting called `libraryPath`. With this setting, you can specify which library you want to upload the files from your source folder. This can help you in projects where you are not in control of where your source files are created. Like for instance with SharePoint Framework.

Greets,
Elio