### PR TITLE
Bug fix when uploading more than 15 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.6] - 2017-08-25
+### Fix
+- Bug fix when uploading more than 15 files. 
+
 ## [1.5.5] - 2017-02-03
 ### Added
 - A new setting called `libraryPath`. This setting, specifies which library to upload the files from.

--- a/index.js
+++ b/index.js
@@ -438,11 +438,11 @@ module.exports = function(args){
 		}
 		
 		var fileDone = function(parameter) {
-			cb(null,file)
+			cb()
 		}
 		
 		if(file.isNull()){
-			cb(null, file)
+			cb()
 			return;
 		}
 		if (file.isStream()) { 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-spsync",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Gulp plugin that syncs with a library in SharePoint Online",
   "main": "index.js",
   "scripts": {
@@ -32,11 +32,9 @@
     "url": "https://github.com/wictorwilen/gulp-spsync/issues"
   },
   "homepage": "https://github.com/wictorwilen/gulp-spsync",
-  "maintainers": [
-    {
-      "name": "wictor",
-      "email": "wictor@wictorwilen.se"
-    }
-  ],
+  "maintainers": [{
+    "name": "wictor",
+    "email": "wictor@wictorwilen.se"
+  }],
   "devDependencies": {}
 }


### PR DESCRIPTION
@wictorwilen the callback functions have to be called without arguments when completed. Apparently when you call it with the null and file arguments, it is causing an issue when more than 15 files are synced.